### PR TITLE
Fix conflict between cover image and title

### DIFF
--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -105,6 +105,7 @@ title_page:
     line_height: 1.0
     margin_top: $base_font_size * 1.15
   subtitle:
+    margin_top: $base_font_size * 2
     font_size: $heading_h2_font_size
     font_style: bold
     line_height: 1

--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -114,7 +114,7 @@ title_page:
     font_size: $base_font_size_large
     font_color: 181818
   revision:
-    margin_top: $base_font_size * 1.25
+    margin_top: 5
 block:
   margin_top: 0
   margin_bottom: $vertical_rhythm

--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -99,7 +99,7 @@ title_page:
     image: image:../isaqb-logo.jpg[pdfwidth=60%,align=center]
     top: 70%
   title:
-    top: 10%
+    top: 0%
     font_size: $heading_h1_font_size
     font_color: 999999
     line_height: 1.0

--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -103,7 +103,7 @@ title_page:
     font_size: $heading_h1_font_size
     font_color: 999999
     line_height: 1.0
-    margin_top: $base_font_size * 1.25
+    margin_top: $base_font_size * 1.15
   subtitle:
     font_size: $heading_h2_font_size
     font_style: bold

--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -97,7 +97,7 @@ title_page:
   align: center
   logo:
     image: image:../isaqb-logo.jpg[pdfwidth=60%,align=center]
-    top: 65%
+    top: 70%
   title:
     top: 10%
     font_size: $heading_h1_font_size


### PR DESCRIPTION
If the title was too long, it would clash with the cover image. Thus, the image is moved downwards, the title is moved upwards and the subtitle format is adjusted.

Closes #7.