### PR TITLE
Add semicolon as delimiter for revision

### DIFF
--- a/themes/isaqb-theme.yml
+++ b/themes/isaqb-theme.yml
@@ -98,6 +98,7 @@ title_page:
     font_color: 181818
   revision:
     margin_top: 5
+    delimiter: '; '
 block:
   margin_top: 0
   margin_bottom: $vertical_rhythm


### PR DESCRIPTION
Since we changed the date format, a simple comma looks weird, especially
when used with an English document. Thus, we use the semicolon (again).

Close #17 